### PR TITLE
enhance(command): Add `<name>` & `<id>` placeholder to `/claiminfo` message.

### DIFF
--- a/src/main/java/net/crashcraft/crashclaim/commands/ClaimInfoCommand.java
+++ b/src/main/java/net/crashcraft/crashclaim/commands/ClaimInfoCommand.java
@@ -43,6 +43,7 @@ public class ClaimInfoCommand extends BaseCommand {
                     "min_z", Integer.toString(claim.getMinZ()),
                     "max_x", Integer.toString(claim.getMaxX()),
                     "max_z", Integer.toString(claim.getMaxZ()),
+                    "name", claim.getName(),
                     "owner", Bukkit.getOfflinePlayer(claim.getOwner()).getName(),
                     "build_status", set.getBuild() == PermState.ENABLED ? enabled : disabled,
                     "entities_status", set.getEntities() == PermState.ENABLED ? enabled : disabled,

--- a/src/main/java/net/crashcraft/crashclaim/commands/ClaimInfoCommand.java
+++ b/src/main/java/net/crashcraft/crashclaim/commands/ClaimInfoCommand.java
@@ -43,6 +43,7 @@ public class ClaimInfoCommand extends BaseCommand {
                     "min_z", Integer.toString(claim.getMinZ()),
                     "max_x", Integer.toString(claim.getMaxX()),
                     "max_z", Integer.toString(claim.getMaxZ()),
+                    "id", Integer.toString(claim.getId()),
                     "name", claim.getName(),
                     "owner", Bukkit.getOfflinePlayer(claim.getOwner()).getName(),
                     "build_status", set.getBuild() == PermState.ENABLED ? enabled : disabled,


### PR DESCRIPTION
This allows `<name>` and `<id>` to be used as a placeholder in the `/claiminfo` message list to display the name/ID of the current claim.

![Screenshot](https://i.imgur.com/rV2R8cL.png)

Optionally if you want to add this to the default messages, I can go through and do that.