### PR TITLE
Add 1.19.1 and 1.19.2 "support"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
 
     // Adventure
     implementation("net.kyori:adventure-api:4.11.0")
-    implementation("net.kyori:adventure-platform-bukkit:4.1.0")
+    implementation("net.kyori:adventure-platform-bukkit:4.1.1")
     implementation("net.kyori:adventure-text-minimessage:4.11.0")
 
     // Other

--- a/src/main/java/net/crashcraft/crashclaim/compatability/CompatabilityManager.java
+++ b/src/main/java/net/crashcraft/crashclaim/compatability/CompatabilityManager.java
@@ -35,7 +35,9 @@ public class CompatabilityManager {
             Wrapper1_18_0.class,
             Wrapper1_18_1.class,
             Wrapper1_18_2.class,
-            Wrapper1_19_0.class
+            Wrapper1_19_0.class,
+            Wrapper1_19_1.class,
+            Wrapper1_19_2.class
     );
 
     public CompatabilityManager(ProtocolManager manager){

--- a/src/main/java/net/crashcraft/crashclaim/compatability/versions/Wrapper1_19_1.java
+++ b/src/main/java/net/crashcraft/crashclaim/compatability/versions/Wrapper1_19_1.java
@@ -1,0 +1,5 @@
+package net.crashcraft.crashclaim.compatability.versions;
+
+public class Wrapper1_19_1 extends Wrapper1_19_0 {
+    // No changes
+}

--- a/src/main/java/net/crashcraft/crashclaim/compatability/versions/Wrapper1_19_2.java
+++ b/src/main/java/net/crashcraft/crashclaim/compatability/versions/Wrapper1_19_2.java
@@ -1,0 +1,5 @@
+package net.crashcraft.crashclaim.compatability.versions;
+
+public class Wrapper1_19_2 extends Wrapper1_19_1 {
+    // No changes
+}


### PR DESCRIPTION
## Change log

### Enhancements

- chore(plugin): Add 1.19.1 and 1.19.2 to the `CompatabilityManager`
- chore(deps): Bump Adventure to latest version