### PR TITLE
fix(command): Fix ejecting Bedrock players with `/claimeject`

### DIFF
--- a/src/main/java/net/crashcraft/crashclaim/commands/EjectCommand.java
+++ b/src/main/java/net/crashcraft/crashclaim/commands/EjectCommand.java
@@ -7,6 +7,7 @@ import co.aikar.commands.annotation.CommandPermission;
 import co.aikar.commands.annotation.Default;
 import co.aikar.commands.annotation.Flags;
 import io.papermc.lib.PaperLib;
+import net.crashcraft.crashclaim.CrashClaim;
 import net.crashcraft.crashclaim.claimobjects.Claim;
 import net.crashcraft.crashclaim.config.GlobalConfig;
 import net.crashcraft.crashclaim.data.ClaimDataManager;
@@ -28,7 +29,14 @@ public class EjectCommand extends BaseCommand {
 
     @Default
     @CommandCompletion("@players @nothing")
-    public void onDefault(Player player, @Flags("other") Player otherPlayer){
+    public void onDefault(Player player, @Flags("other") String value){
+        Player otherPlayer = CrashClaim.getPlugin().getServer().getPlayer(value);
+
+        if (otherPlayer == null) {
+            player.spigot().sendMessage(Localization.EJECT__INVALID_PLAYER.getMessage(player));
+            return;
+        }
+
         Location location = player.getLocation();
         Claim claim = manager.getClaim(location.getBlockX(), location.getBlockZ(), location.getWorld().getUID());
         if (claim != null){

--- a/src/main/java/net/crashcraft/crashclaim/localization/Localization.java
+++ b/src/main/java/net/crashcraft/crashclaim/localization/Localization.java
@@ -44,6 +44,7 @@ public enum Localization {
     BYPASS__DISABLED("<red>Disabled claim bypass."),
 
     EJECT__NO_PERMISSION("<red>You do not have the modify permission ability inside this claim."),
+    EJECT__INVALID_PLAYER("<red>The specified player could not be found."),
     EJECT__NOT_SAME_CLAIM("<red>That player is not standing in the same claim as you."),
     EJECT__HAS_PERMISSION("<red>That player has the modify permissions ability inside this claim and cannot be ejected."),
     EJECT__BEEN_EJECTED("<red>You have been ejected from the claim you were standing in by another player."),


### PR DESCRIPTION
- fix(command): Fix ejecting Bedrock players with `/claimeject`
- chore(locale): Add `EJECT__INVALID_PLAYER` locale for invalid players when using `/claimeject`