### PR TITLE
Small Fixes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,7 @@ dependencies {
     implementation("org.bstats:bstats-bukkit:3.0.1")
     compileOnly("com.google.guava:guava:31.1-jre")
     //compileOnly( "com.comphenix.protocol:ProtocolLib:4.7.1-SNAPSHOT")
-    compileOnly("com.github.dmulloy2:ProtocolLib:-SNAPSHOT")
+    compileOnly("com.github.dmulloy2:ProtocolLib:5.1.0")
     compileOnly( "net.milkbowl.vault:VaultAPI:1.7")
     compileOnly( "com.sk89q.worldguard:worldguard-bukkit:7.0.5")
     compileOnly( "com.github.TechFortress:GriefPrevention:16.16.0")

--- a/src/main/java/net/crashcraft/crashclaim/commands/MenuCommand.java
+++ b/src/main/java/net/crashcraft/crashclaim/commands/MenuCommand.java
@@ -54,8 +54,10 @@ public class MenuCommand extends BaseCommand {
     @CommandPermission("crashclaim.user.unclaimsubclaim")
     public void unSubClaim(Player player){
         Location location = player.getLocation();
-        SubClaim claim = manager.getClaim(location.getBlockX(), location.getBlockZ(), location.getWorld().getUID()).getSubClaim(location.getBlockX(), location.getBlockZ());
-        if (claim != null){
+        final Claim claim = manager.getClaim(location.getBlockX(), location.getBlockZ(), location.getWorld().getUID());
+        SubClaim subClaim;
+        subClaim = (claim != null) ? claim.getSubClaim(location.getBlockX(), location.getBlockZ()) : null;
+        if (subClaim != null){
             ItemStack message = Localization.UN_SUBCLAIM__MENU__CONFIRMATION__MESSAGE.getItem(player);
             message.setType(GlobalConfig.visual_menu_items.getOrDefault(claim.getWorld(), Material.OAK_FENCE));
 
@@ -66,14 +68,14 @@ public class MenuCommand extends BaseCommand {
                     Localization.UN_SUBCLAIM__MENU__CONFIRMATION__DENY.getItem(player),
                     (p, aBoolean) -> {
                         if (aBoolean) {
-                            if (PermissionHelper.getPermissionHelper().hasPermission(claim, p.getUniqueId(), PermissionRoute.MODIFY_CLAIM)) {
-                                CrashClaim.getPlugin().getDataManager().deleteSubClaim(claim);
+                            if (PermissionHelper.getPermissionHelper().hasPermission(subClaim, p.getUniqueId(), PermissionRoute.MODIFY_CLAIM)) {
+                                CrashClaim.getPlugin().getDataManager().deleteSubClaim(subClaim);
 
                                 VisualGroup group = visualizationManager.fetchVisualGroup(player, false);
                                 if (group != null){
                                     group.removeAllVisuals();
 
-                                    BaseVisual visual = visualizationManager.getProvider(p.getUniqueId()).spawnClaimVisual(VisualColor.GREEN, group, claim.getParent(), player.getLocation().getBlockY() - 1);
+                                    BaseVisual visual = visualizationManager.getProvider(p.getUniqueId()).spawnClaimVisual(VisualColor.GREEN, group, subClaim.getParent(), player.getLocation().getBlockY() - 1);
                                     visual.spawn();
 
                                     visualizationManager.deSpawnAfter(visual, 10);

--- a/src/main/java/net/crashcraft/crashclaim/config/GlobalConfig.java
+++ b/src/main/java/net/crashcraft/crashclaim/config/GlobalConfig.java
@@ -50,12 +50,15 @@ public class GlobalConfig extends BaseConfig{
     public static boolean visual_use_highest_block;
     public static HashMap<UUID, Material> visual_menu_items;
 
+    public static Material visual_subclaim_item;
+
     public static int visual_alert_fade_in;
     public static int visual_alert_duration;
     public static int visual_alert_fade_out;
 
     private static void loadVisual(){
         visual_type = getString("visualization.visual-type", "glow");
+        visual_subclaim_item =  Material.valueOf(getString("visualization.sub-claim-item", "PAPER"));
 
         visual_menu_items = new HashMap<>();
 

--- a/src/main/java/net/crashcraft/crashclaim/listeners/PlayerListener.java
+++ b/src/main/java/net/crashcraft/crashclaim/listeners/PlayerListener.java
@@ -30,6 +30,7 @@ import org.bukkit.event.block.BlockIgniteEvent;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 import org.bukkit.event.block.BlockPistonRetractEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
@@ -125,6 +126,7 @@ public class PlayerListener implements Listener {
         }
     }
 
+
     @EventHandler (priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void onPlayerInteractEvent(PlayerInteractEvent e){
         if (e.getClickedBlock() == null)
@@ -136,6 +138,7 @@ public class PlayerListener implements Listener {
         if (GlobalConfig.disabled_worlds.contains(location.getWorld().getUID())){
             return;
         }
+
 
         if (e.getAction().equals(Action.RIGHT_CLICK_BLOCK) && e.getItem() != null && perms.getHeldItemInteraction().contains(e.getItem().getType())) {
             if (!helper.hasPermission(player.getUniqueId(), location, PermissionRoute.ENTITIES)){

--- a/src/main/java/net/crashcraft/crashclaim/localization/Localization.java
+++ b/src/main/java/net/crashcraft/crashclaim/localization/Localization.java
@@ -482,6 +482,7 @@ public enum Localization {
             item.addUnsafeEnchantment(Enchantment.BINDING_CURSE, 1);
             ItemMeta meta = item.getItemMeta(); // Stupid spigot api
             meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            meta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
 
             item.setItemMeta(meta);
             return item;
@@ -747,6 +748,7 @@ public enum Localization {
 
             ItemStack item = new ItemStack(material, stackSize);
             ItemMeta iMeta = item.getItemMeta();
+            iMeta.addItemFlags(ItemFlag.HIDE_ATTRIBUTES);
 
             String newTitle = hasPlaceholders ? LocalizationLoader.placeholderManager.usePlaceholders(player, title) : title;
             iMeta.setDisplayName(BukkitComponentSerializer.legacy().serialize(Component.empty().decoration(TextDecoration.ITALIC, false).append(LocalizationLoader.parser.deserialize(newTitle, generateTagResolver(replace)))));

--- a/src/main/java/net/crashcraft/crashclaim/menus/SubClaimMenu.java
+++ b/src/main/java/net/crashcraft/crashclaim/menus/SubClaimMenu.java
@@ -20,6 +20,8 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.inventory.ItemStack;
 
+import static net.crashcraft.crashclaim.config.GlobalConfig.visual_subclaim_item;
+
 public class SubClaimMenu extends GUI {
     private final SubClaim claim;
     private final PermissionHelper helper;
@@ -61,7 +63,7 @@ public class SubClaimMenu extends GUI {
             );
         }
 
-        descItem.setType(Material.PAPER);
+        descItem.setType(visual_subclaim_item);
         inv.setItem(13, descItem);
 
         if (helper.hasPermission(claim, getPlayer().getUniqueId(), PermissionRoute.MODIFY_PERMISSIONS)) {

--- a/src/main/java/net/crashcraft/crashclaim/menus/list/PlayerPermListMenu.java
+++ b/src/main/java/net/crashcraft/crashclaim/menus/list/PlayerPermListMenu.java
@@ -1,12 +1,12 @@
 package net.crashcraft.crashclaim.menus.list;
 
 import dev.whip.crashutils.menusystem.GUI;
-import dev.whip.crashutils.menusystem.defaultmenus.PlayerListMenu;
 import net.crashcraft.crashclaim.claimobjects.BaseClaim;
 import net.crashcraft.crashclaim.claimobjects.Claim;
 import net.crashcraft.crashclaim.claimobjects.SubClaim;
 import net.crashcraft.crashclaim.localization.Localization;
 import net.crashcraft.crashclaim.menus.permissions.SimplePermissionMenu;
+import net.crashcraft.crashclaim.menus.utils.PlayerListMenu;
 import net.crashcraft.crashclaim.permissions.PermissionHelper;
 import net.crashcraft.crashclaim.permissions.PermissionRoute;
 import net.md_5.bungee.api.chat.BaseComponent;

--- a/src/main/java/net/crashcraft/crashclaim/menus/utils/PlayerListMenu.java
+++ b/src/main/java/net/crashcraft/crashclaim/menus/utils/PlayerListMenu.java
@@ -1,0 +1,153 @@
+package net.crashcraft.crashclaim.menus.utils;
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import dev.whip.crashutils.CrashUtils;
+import dev.whip.crashutils.menusystem.GUI;
+import io.papermc.lib.PaperLib;
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.BiFunction;
+
+public class PlayerListMenu extends GUI {
+    private int page = 1;
+    private final GUI previousMenu;
+    private final BiMap<UUID, String> lookupMap = HashBiMap.create();
+    private final ArrayList<UUID> arrayList;
+    private final BiFunction<GUI, UUID, String> function;
+
+    public PlayerListMenu(String title, Player player, GUI previousMenu, ArrayList<UUID> arrayList, BiFunction<GUI, UUID, String> function){
+        super(player, title == null ? "Select Player" : title, 54);
+        this.previousMenu = previousMenu;
+        this.arrayList = arrayList;
+        this.function = function;
+        for (UUID uuid : arrayList) {
+            String name = Bukkit.getOfflinePlayer(uuid).getName();
+            if (lookupMap.containsValue(name)) {
+                lookupMap.put(uuid, name + " - " + uuid.toString());
+            } else {
+                lookupMap.put(uuid, name);
+            }
+        }
+        setupGUI();
+    }
+
+    @Override
+    public void initialize() {
+
+    }
+
+    @Override
+    public void loadItems() {
+        inv.clear();
+
+        HashMap<Integer, UUID> headMap = new HashMap<>();
+
+        final boolean isPaper = PaperLib.isPaper();
+
+        int slot = 10;
+        for (UUID uuid : getPageFromArray()){
+            while ((slot%9)<1 || (slot%9)>7){
+                slot++;
+            }
+
+            if (isPaper) {
+                inv.setItem(slot, createGuiItem(lookupMap.get(uuid), Material.PLAYER_HEAD));
+                headMap.put(slot, uuid);
+            } else {
+                inv.setItem(slot, createPlayerHead(uuid, lookupMap.get(uuid)));
+            }
+
+            slot++;
+        }
+
+        if (isPaper) {
+            Bukkit.getScheduler().runTaskAsynchronously(CrashUtils.getPlugin(), () -> {
+                HashMap<Integer, ItemStack> realHeadMap = new HashMap<>();
+
+                for (Map.Entry<Integer, UUID> entry : headMap.entrySet()) {
+                    PlayerProfile profile = Bukkit.createProfile(entry.getValue());
+
+                    if (profile.complete()) {
+                        ItemStack item = createGuiItem(profile.getName(), Material.PLAYER_HEAD);
+                        SkullMeta meta = (SkullMeta) item.getItemMeta();
+                        meta.setPlayerProfile(profile);
+                        item.setItemMeta(meta);
+
+                        realHeadMap.put(entry.getKey(), item);
+                    }
+                }
+
+                Bukkit.getScheduler().runTask(CrashUtils.getPlugin(), () -> {
+                    for (Map.Entry<Integer, ItemStack> entry : realHeadMap.entrySet()) {
+                        inv.setItem(entry.getKey(), entry.getValue());
+                    }
+                });
+            });
+        }
+
+        //Controls
+        if (page > 1) {
+            inv.setItem(48, createGuiItem( "§5§lᴘʀᴇᴄᴇᴅᴇɴᴛᴇ", Material.RED_DYE));
+        }
+
+        inv.setItem(49, createGuiItem("§5§lᴘᴀɢɪɴᴀ§r §8(§7" + page + "§8/§7" + ((int)Math.ceil((float) arrayList.size() / 21) + 1)+"§8)",
+                Material.CONDUIT));
+
+        if (arrayList.size() > page * 21) {
+            inv.setItem(50, createGuiItem("§5§lsᴜᴄᴄᴇssɪᴠᴀ", Material.LIME_DYE));
+        }
+
+        inv.setItem(45, createGuiItem("§5§lɪɴᴅɪᴇᴛʀᴏ", Material.GRAY_DYE));
+    }
+
+    @Override
+    public void onClose() {
+
+    }
+
+    @Override
+    public void onClick(InventoryClickEvent event, String rawItemName) {
+        switch (rawItemName) {
+            case "ᴘʀᴇᴄᴇᴅᴇɴᴛᴇ":
+                if (page > 1) {
+                    page--;
+                    loadItems();
+                }
+                break;
+            case "sᴜᴄᴄᴇssɪᴠᴀ":
+                page++;
+                loadItems();
+                break;
+            case "ɪɴᴅɪᴇᴛʀᴏ":
+                previousMenu.initialize();
+                previousMenu.open();
+                break;
+            default:
+                if (event.getCurrentItem().getType() == Material.PLAYER_HEAD) {
+                    function.apply(this, lookupMap.inverse().get(ChatColor.stripColor(event.getCurrentItem().getItemMeta().getDisplayName())));
+                }
+                break;
+        }
+    }
+
+    private ArrayList<UUID> getPageFromArray(){
+        ArrayList<UUID> pageItems = new ArrayList<>();
+
+        for (int x = 21 * (page - 1); x < 21 * page && x < arrayList.size(); x++){
+            pageItems.add(arrayList.get(x));
+        }
+
+        return pageItems;
+    }
+}

--- a/src/main/java/net/crashcraft/crashclaim/permissions/PermissionSetup.java
+++ b/src/main/java/net/crashcraft/crashclaim/permissions/PermissionSetup.java
@@ -3,6 +3,7 @@ package net.crashcraft.crashclaim.permissions;
 import net.crashcraft.crashclaim.CrashClaim;
 import net.crashcraft.crashclaim.claimobjects.PermState;
 import net.crashcraft.crashclaim.claimobjects.permission.PlayerPermissionSet;
+import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Container;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -87,6 +88,10 @@ public class PermissionSetup {
 
             Material material = Material.getMaterial(name);
 
+            if(name.equals("EGG*")){
+                eggMaterials();
+            }
+
             if (material != null) {
                 heldItemInteraction.add(material);
             } else {
@@ -111,6 +116,14 @@ public class PermissionSetup {
                 PermState.ENABLED,
                 PermState.ENABLED,
                 PermState.ENABLED);
+    }
+
+    private void eggMaterials(){
+        for (Material EGG : org.bukkit.Material.values()){
+            if(EGG.toString().contains("EGG")){
+                heldItemInteraction.add(EGG);
+            }
+        }
     }
 
     public ArrayList<Material> getTrackedContainers() {

--- a/src/main/resources/lookup.yml
+++ b/src/main/resources/lookup.yml
@@ -1,6 +1,7 @@
 untracked-blocks:
   - ""
-
+tracked-heldItemInteraction:
+  - "EGG*"
 #An issue with the Bukkit API has required this list to add intractable block materials to an incomplete list.
 #If a block is not falling under the interaction category then add it to this list. Use the Bukkit material name.
 additional-tracked-interactables:
@@ -25,4 +26,4 @@ additional-tracked-interactables:
   - "PUMPKIN_STEM"
   - "SWEET_BERRY_BUSH"
   - "WHEAT"
-  - "WHEAT"
+  - "SPAWNER"


### PR DESCRIPTION
Fixes:
- NullPointer on /subclaim while not standing in any type/form of claim
- Items in GUI showing attributes (Like Tools, Swords...)  
- Players able to use SpawnEGGS in claims
- Lookup.yml missing a configuration section  
  
Added:
- Option in config to set the visual item for subclaims
- Quick Option to blacklist all the EGGS

NOTE:
- Ignore commit about Default GUI Buttons